### PR TITLE
Fix LeafNode HTML output for images

### DIFF
--- a/src/leafnode.py
+++ b/src/leafnode.py
@@ -9,15 +9,18 @@ class LeafNode(HTMLNode):
         super().__init__(tag, value, None, props)
 
     def to_html(self):
+        if self.tag is None:
+            if self.value is None:
+                raise ValueError("all leaf nodes must have a value")
+            return self.value
+
+        if self.tag == "img":
+            return f"<img{self.props_to_html()}>"
+
         if not self.value:
             raise ValueError("all leaf nodes must have a value")
-        
-        if self.tag is None:
-            return self.value
-        
-        return (
-            f"<{self.tag}{self.props_to_html()}>{self.value}</{self.tag}>"
-        )
+
+        return f"<{self.tag}{self.props_to_html()}>{self.value}</{self.tag}>"
     
     def __repr__(self):
         return f"LeafNode({self.tag}, {self.value}, {self.props})"

--- a/src/test_leafnode.py
+++ b/src/test_leafnode.py
@@ -16,6 +16,17 @@ class TestLeafNode(unittest.TestCase):
         node = LeafNode(None, "Just plain text.")
         self.assertEqual(node.to_html(), "Just plain text.")
 
+    def test_leaf_to_html_image(self):
+        node = LeafNode(
+            "img",
+            "",
+            {"src": "https://example.com/img.png", "alt": "alt text"},
+        )
+        self.assertEqual(
+            node.to_html(),
+            '<img src="https://example.com/img.png" alt="alt text">',
+        )
+
     def test_failures(self):
         try:
             node = LeafNode("p", "")


### PR DESCRIPTION
## Summary
- allow LeafNode to render `<img>` tags with no value
- update tests for LeafNode to cover image case

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68830513fc3c8322abea2d2c90d1da6c